### PR TITLE
Factor out getCreateTime function

### DIFF
--- a/src/Network/AWS/S3/Cache/Remote.hs
+++ b/src/Network/AWS/S3/Cache/Remote.hs
@@ -49,6 +49,12 @@ import Network.HTTP.Types.Status (Status(statusMessage), status404)
 import Prelude as P
 import System.IO (hClose)
 
+-- | Returns the time when the cache object was created
+getCreateTime :: GetObjectResponse -> Maybe UTCTime
+getCreateTime resp =
+  (HM.lookup metaCreateTimeKey (resp ^. gorsMetadata) >>= parseISO8601) <|>
+  (resp ^. gorsLastModified)
+
 -- | Will check if there is already cache up on AWS and checks if it's contents has changed.
 -- Returns create time date if new cache should be uploaded.
 hasCacheChanged ::
@@ -76,9 +82,7 @@ hasCacheChanged newHash = do
       onSucc resp = do
         logAWS LevelDebug "Discovered previous cache."
         let mOldHash = HM.lookup hashKey (resp ^. gorsMetadata)
-            mCreateTime =
-              (HM.lookup metaCreateTimeKey (resp ^. gorsMetadata) >>= parseISO8601) <|>
-              (resp ^. gorsLastModified)
+            mCreateTime = getCreateTime resp
         case mOldHash of
           Just oldHash ->
             logAWS LevelDebug $ "Hash value for previous cache is " <> hashKey <> ": " <> oldHash
@@ -243,11 +247,7 @@ downloadCache sink = do
       HM.lookup hashAlgName (resp ^. gorsMetadata) `onNothing`
       logAWS LevelWarn ("Cache is missing a hash value '" <> hashAlgName <> "'")
     logAWS LevelDebug $ "Hash value is " <> hashAlgName <> ": " <> hashTxt
-    let mCreateTime = do
-          createTimeTxt <- HM.lookup metaCreateTimeKey (resp ^. gorsMetadata)
-          parseISO8601 createTimeTxt
-    createTime <-
-      (mCreateTime <|> (resp ^. gorsLastModified)) `onNothing`
+    createTime <- getCreateTime resp `onNothing`
       logAWS LevelWarn "Cache is missing creation time info."
     logAWS LevelDebug $ "Cache creation timestamp:  " <> formatRFC822 createTime
     case c ^. maxAge of

--- a/src/Network/AWS/S3/Cache/Remote.hs
+++ b/src/Network/AWS/S3/Cache/Remote.hs
@@ -278,8 +278,9 @@ downloadCache sink = do
         (resp ^. gorsContentLength) `onNothing`
         logAWS LevelError "Did not receive expected cache size form AWS"
       logAWS LevelInfo $
-        "Restoring cache from " <> formatRFC822 createTime <> " with total size: " <>
-        formatBytes len
+        "Restoring cache from " <>
+        formatRFC822 (fromMaybe createTime (resp ^. gorsLastModified)) <>
+        " with total size: " <> formatBytes len
       logger <- getLoggerIO
       hashComputed <-
         liftIO $


### PR DESCRIPTION
This patch factors out a `getCreateTime` function which tries to retrieve object creation time or the last modification time, in this order.

This PR was extracted from #21 