### PR TITLE
Retry after failing data transfer

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -111,7 +111,12 @@ commonArgsParser version mS3Bucket =
     (long "max-size" <> metavar "SIZE" <> value Nothing <>
      help
        "Maximum size of cache that will be acceptable for uploading/downloading to/from S3. \
-          \Examples: 5Gb, 750mb, etc. ") <*
+          \Examples: 5Gb, 750mb, etc. ") <*>
+  option
+    auto
+    (long "num-retries" <> metavar "N" <> value 3 <>
+     help
+       "Retry a failing data transfer at most N times. (Default is 3)") <*
   infoOption
     ("cache-s3-" <> showVersion version)
     (long "version" <> help "Print current verison of the program.")

--- a/src/Network/AWS/S3/Cache.hs
+++ b/src/Network/AWS/S3/Cache.hs
@@ -108,7 +108,7 @@ mkConfig CommonArgs {..} = do
   let env = maybe envInit (\reg -> envInit & envRegion .~ reg) commonRegion
   mGitBranch <- maybe (liftIO $ getBranchName commonGitDir) (return . Just) commonGitBranch
   let objKey = mkObjectKey commonPrefix mGitBranch commonSuffix
-  return $ Config commonBucket objKey env commonVerbosity commonConcise Nothing commonMaxBytes
+  return $ Config commonBucket objKey env commonVerbosity commonConcise Nothing commonMaxBytes commonNumRetries
 
 
 runCacheS3 :: CommonArgs -> Action -> IO ()
@@ -148,6 +148,7 @@ runCacheS3 ca@CommonArgs {..} action = do
               commonConcise
               restoreMaxAge
               commonMaxBytes
+              commonNumRetries
         _ -> return ()
     RestoreStack (RestoreStackArgs {..}) -> do
       resolver <- getStackResolver restoreStackProject

--- a/src/Network/AWS/S3/Cache/Remote.hs
+++ b/src/Network/AWS/S3/Cache/Remote.hs
@@ -67,6 +67,7 @@ hasCacheChanged ::
      , MonadThrow m
      , HasBucketName r BucketName
      , HasObjectKey r ObjectKey
+     , HasNumRetries r Int
      , HasEnv r
      , HasMinLogLevel r L.LogLevel
      , HashAlgorithm h
@@ -126,6 +127,7 @@ uploadCache ::
      , HasObjectKey r ObjectKey
      , HasBucketName r BucketName
      , HasMaxSize r (Maybe Integer)
+     , HasNumRetries r Int
      , MonadResource m
      , MonadLoggerIO m
      , MonadThrow m
@@ -203,6 +205,7 @@ deleteCache ::
      , MonadThrow m
      , HasEnv c
      , HasMinLogLevel c L.LogLevel
+     , HasNumRetries c Int
      , HasObjectKey c ObjectKey
      , HasBucketName c BucketName
      )
@@ -225,6 +228,7 @@ downloadCache ::
      , HasBucketName c BucketName
      , HasMaxAge c (Maybe NominalDiffTime)
      , HasMaxSize c (Maybe Integer)
+     , HasNumRetries c Int
      )
   => (forall h . HashAlgorithm h =>
        (L.LogLevel -> Text -> IO ())
@@ -320,6 +324,7 @@ sendAWS ::
      , HasEnv r
      , HasMinLogLevel r L.LogLevel
      , HasObjectKey r ObjectKey
+     , HasNumRetries r Int
      , AWSRequest a
      , MonadLogger m
      , MonadThrow m
@@ -338,6 +343,7 @@ sendAWS_ ::
      , MonadResource m
      , HasEnv r
      , HasMinLogLevel r L.LogLevel
+     , HasNumRetries r Int
      , HasObjectKey r ObjectKey
      , AWSRequest a
      , MonadLogger m
@@ -355,6 +361,7 @@ runLoggingAWS_ ::
      , MonadResource m
      , HasEnv r
      , HasMinLogLevel r L.LogLevel
+     , HasNumRetries r Int
      , HasObjectKey r ObjectKey
      , MonadLogger m
      , MonadThrow m
@@ -370,6 +377,7 @@ runLoggingAWS ::
      , MonadResource m
      , HasEnv r
      , HasMinLogLevel r L.LogLevel
+     , HasNumRetries r Int
      , HasObjectKey r ObjectKey
      , MonadLogger m
      , MonadThrow m
@@ -380,7 +388,7 @@ runLoggingAWS ::
   -> m b
 runLoggingAWS action onErr onSucc = do
   conf <- ask
-  eResp <- runAWS conf $ trying _Error action
+  eResp <- retryWith (runAWS conf $ trying _Error action)
   case eResp of
     Left err -> do
       (errMsg, status) <-

--- a/src/Network/AWS/S3/Cache/Types.hs
+++ b/src/Network/AWS/S3/Cache/Types.hs
@@ -54,6 +54,7 @@ data Config = Config
   , _isConcise   :: !Bool
   , _maxAge      :: !(Maybe NominalDiffTime)
   , _maxSize     :: !(Maybe Integer)
+  , _numRetries  :: !Int
   }
 
 makeLensesWith classUnderscoreNoPrefixFields ''Config
@@ -78,15 +79,16 @@ mkObjectKey mPrefix mBranchName mSuffix =
 
 
 data CommonArgs = CommonArgs
-  { commonBucket    :: !BucketName
-  , commonRegion    :: !(Maybe Region)
-  , commonPrefix    :: !(Maybe Text)
-  , commonGitDir    :: !(Maybe FilePath)
-  , commonGitBranch :: !(Maybe Text)
-  , commonSuffix    :: !(Maybe Text)
-  , commonVerbosity :: !L.LogLevel
-  , commonConcise   :: !Bool
-  , commonMaxBytes  :: !(Maybe Integer)
+  { commonBucket     :: !BucketName
+  , commonRegion     :: !(Maybe Region)
+  , commonPrefix     :: !(Maybe Text)
+  , commonGitDir     :: !(Maybe FilePath)
+  , commonGitBranch  :: !(Maybe Text)
+  , commonSuffix     :: !(Maybe Text)
+  , commonVerbosity  :: !L.LogLevel
+  , commonConcise    :: !Bool
+  , commonMaxBytes   :: !(Maybe Integer)
+  , commonNumRetries :: !Int
   } deriving (Show)
 
 


### PR DESCRIPTION
This PR wraps all data transfer operations in a simple retry mechanism. The number of retries is configurable via a command line.

A failing action is retried in case a TransportError occurs.

Solves #24 