### PR TITLE
Fix #27 - refactored all of the package to use RIO. Other improvements:

### DIFF
--- a/cache-s3.cabal
+++ b/cache-s3.cabal
@@ -20,9 +20,9 @@ library
   exposed-modules:     Network.AWS.S3.Cache
                      , Network.AWS.S3.Cache.Local
   other-modules:       Network.AWS.S3.Cache.Remote
-                     , Network.AWS.S3.Cache.Types
                      , Network.AWS.S3.Cache.Stack
-                     , Paths_cache_s3
+                     , Network.AWS.S3.Cache.Types
+                       Paths_cache_s3
   build-depends:       aeson
                      , amazonka
                      , amazonka-core
@@ -36,27 +36,19 @@ library
                      , conduit-extra
                      , cryptonite
                      , cryptonite-conduit
-                     , directory >= 1.3.0.0
-                     , fast-logger >= 2.1.0
-                     , filepath
                      , git
                      , http-client
                      , http-types
                      , lens
                      , memory
-                     , monad-control
-                     , monad-logger
                      , mtl
-                     , process
                      , resourcet
-                     , safe-exceptions
+                     , rio
+                     , rio-orphans
                      , tar-conduit >= 0.2.0
                      , text
-                     , time
                      , transformers >= 0.5.2.0
                      , unliftio
-                     , unordered-containers
-                     , vector >= 0.12.0.0
                      , yaml
   default-language:    Haskell2010
   ghc-options:         -Wall
@@ -76,7 +68,7 @@ executable cache-s3
                      , base
                      , cache-s3
                      , optparse-applicative
-                     , text
+                     , rio
   default-language:    Haskell2010
 
 test-suite tests

--- a/src/Network/AWS/S3/Cache.hs
+++ b/src/Network/AWS/S3/Cache.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 -- |
 -- Module      : Network.AWS.S3.Cache
 -- Copyright   : (c) FP Complete 2017
@@ -13,157 +14,144 @@
 module Network.AWS.S3.Cache
   ( runCacheS3
   , cacheS3Version
-  , L.LogLevel(..)
+  , mkCacheS3LogFunc
   , module Network.AWS.S3.Cache.Types
   ) where
 
-import Control.Exception.Safe (MonadCatch)
 import Control.Lens
-import Control.Monad (when)
-import Control.Monad.Logger as L
 import Control.Monad.Reader
-import Control.Monad.Trans.AWS
-import Control.Monad.Trans.Maybe
-import Control.Monad.Trans.Resource (ResourceT)
-import Data.ByteString.Char8 as S8
-import Data.Monoid ((<>))
-import Data.Text as T
-import Data.Time
+import Control.Monad.Trans.AWS hiding (LogLevel)
+import RIO.Text as T
 import Data.Version (Version)
+import Data.ByteString.Builder.Extra (flush)
 import Network.AWS.S3.Cache.Local
 import Network.AWS.S3.Cache.Remote
 import Network.AWS.S3.Cache.Stack
 import Network.AWS.S3.Cache.Types
 import qualified Paths_cache_s3 as Paths
 import Prelude as P
-import System.Exit
-import System.Log.FastLogger (fromLogStr)
-import UnliftIO
+import RIO hiding ((^.))
+import RIO.Time
 
-showLogLevel :: L.LogLevel -> LogStr
+
+showLogLevel :: RIO.LogLevel -> Utf8Builder
 showLogLevel level =
   case level of
     LevelDebug   -> "Debug"
     LevelInfo    -> "Info "
     LevelWarn    -> "Warn "
     LevelError   -> "Error"
-    LevelOther o -> "Other " <> toLogStr o
+    LevelOther o -> "Other " <> display o
 
-customLoggerT ::
-     Bool -- ^ Should logger be concise (ommit timestamp and app name)
-  -> L.LogLevel -- ^ Minimum log level
-  -> LoggingT m a
-  -> m a
-customLoggerT con minLevel (LoggingT f) = do
-  f $ \_ _ level msg ->
-    when (level >= minLevel) $ do
-      let levelStr = "[" <> showLogLevel level <> "]"
+mkCacheS3LogFunc ::
+     Handle
+  -> Bool -- ^ Should logger be concise (ommit timestamp and app name)
+  -> LogLevel -- ^ Minimum log level
+  -> LogFunc
+mkCacheS3LogFunc handle' con minLevel =
+  mkLogFunc $ \_callstack _logSource logLevel msg ->
+    when (logLevel >= minLevel) $ do
+      let levelStr = "[" <> showLogLevel logLevel <> "]"
       entryPrefix <-
         if con
           then return $ levelStr <> ": "
           else do
             now <- getCurrentTime
-            return $ "[cache-s3]" <> levelStr <> "[" <> toLogStr (formatRFC822 now) <> "]: "
-      S8.putStrLn $ fromLogStr (entryPrefix <> msg)
-      when (level == LevelError) $ exitWith (ExitFailure 1)
+            return $ "[cache-s3]" <> levelStr <> "[" <> formatRFC822 now <> "]: "
+      hPutBuilder handle' $ getUtf8Builder (entryPrefix <> msg <> "\n") <> flush
+      when (logLevel == LevelError) $ exitWith (ExitFailure 1)
 
 
-
--- | Run the cache action.
-run ::
-     (MonadUnliftIO m, HasIsConcise r Bool, HasMinLogLevel r L.LogLevel)
-  => ReaderT r (LoggingT (ResourceT m)) a
-  -> r
-  -> m a
-run action conf =
-  runResourceT $
-  customLoggerT (conf ^. isConcise) (conf ^. minLogLevel) $ runReaderT action conf
-
-
-saveCache :: Bool -> Text -> Compression -> [FilePath] -> [FilePath] -> Config -> IO ()
-saveCache isPublic hAlgTxt comp dirs relativeDirs conf = do
+saveCache :: Bool -> Text -> Compression -> [FilePath] -> [FilePath] -> RIO Config ()
+saveCache isPublic hAlgTxt comp dirs relativeDirs =
   let hashNoSupport sup =
-        logErrorN $
-        "Hash algorithm '" <> hAlgTxt <> "' is not supported, use one of these instead: " <>
-        T.intercalate ", " sup
-  run
-    (withHashAlgorithm_ hAlgTxt hashNoSupport $ \hAlg ->
-       withSystemTempFile (makeTempFileNamePattern comp) $ \fp hdl ->
-         let tmpFile = TempFile fp hdl comp
-          in do
-           logger <- getLoggerIO
-           sizeAndHash <- liftIO $ runResourceT $ writeCacheTempFile logger dirs relativeDirs hAlg tmpFile
-           void $ runMaybeT $ uploadCache isPublic tmpFile sizeAndHash)
-    conf
+        logError $
+        "Hash algorithm '" <> display hAlgTxt <> "' is not supported, use one of these instead: " <>
+        display (T.intercalate ", " sup)
+   in withHashAlgorithm_ hAlgTxt hashNoSupport $ \hAlg ->
+        withSystemTempFile (makeTempFileNamePattern comp) $ \fp hdl ->
+          let tmpFile = TempFile fp hdl comp
+           in do sizeAndHash <- writeCacheTempFile dirs relativeDirs hAlg tmpFile
+                 uploadCache isPublic tmpFile sizeAndHash
 
 
-restoreCache :: FileOverwrite -> Config -> IO Bool
-restoreCache overwrite =
-  run (maybe False (const True) <$> runMaybeT (downloadCache (restoreFilesFromCache overwrite)))
 
-mkConfig :: (MonadIO m, MonadCatch m) =>
-            CommonArgs -> m Config
-mkConfig CommonArgs {..} = do
-  envInit <- newEnv Discover
+withConfig :: CommonArgs -> (Config -> RIO App a) -> RIO App a
+withConfig CommonArgs {..} innerAction = do
+  envInit <- liftIO $ newEnv Discover
   let env = maybe envInit (\reg -> envInit & envRegion .~ reg) commonRegion
-  mGitBranch <- maybe (liftIO $ getBranchName commonGitDir) (return . Just) commonGitBranch
+  mGitBranch <- maybe (getBranchName commonGitDir) (return . Just) commonGitBranch
   let objKey = mkObjectKey commonPrefix mGitBranch commonSuffix
-  return $ Config commonBucket objKey env commonVerbosity commonConcise Nothing commonMaxBytes commonNumRetries
+  app <- ask
+  innerAction $
+    Config
+      commonBucket
+      objKey
+      env
+      commonVerbosity
+      commonConcise
+      Nothing
+      commonMaxBytes
+      commonNumRetries
+      app
 
 
-runCacheS3 :: CommonArgs -> Action -> IO ()
+runCacheS3 :: CommonArgs -> Action -> RIO App ()
 runCacheS3 ca@CommonArgs {..} action = do
   let caAddSuffix suf = ca {commonSuffix = ((<> ".") <$> commonSuffix) <> Just suf}
       caStackSuffix res = caAddSuffix (res <> ".stack")
       caStackWorkSuffix res = caAddSuffix (res <> ".stack-work")
   case action of
-    Save (SaveArgs {..}) -> do
-      config <- mkConfig ca
-      saveCache savePublic saveHash saveCompression savePaths saveRelativePaths config
-    SaveStack (SaveStackArgs {..}) -> do
+    Save SaveArgs {..} ->
+      withConfig ca $ \config ->
+        runRIO config $ saveCache savePublic saveHash saveCompression savePaths saveRelativePaths
+    SaveStack SaveStackArgs {..} -> do
       stackGlobalPaths <- getStackGlobalPaths saveStackRoot
       resolver <- getStackResolver saveStackProject
       runCacheS3 (caStackSuffix resolver) $
         Save saveStackArgs {savePaths = savePaths saveStackArgs ++ stackGlobalPaths}
-    SaveStackWork (SaveStackWorkArgs {..}) -> do
+    SaveStackWork SaveStackWorkArgs {..} -> do
       let SaveStackArgs {..} = saveStackWorkArgs
           StackProject {..} = saveStackProject
       stackLocalPaths <- getStackWorkPaths saveStackRoot stackYaml saveStackWorkDir
       resolver <- getStackResolver saveStackProject
       runCacheS3 (caStackWorkSuffix resolver) $
         Save saveStackArgs {savePaths = savePaths saveStackArgs ++ stackLocalPaths}
-    Restore (RestoreArgs {..}) -> do
-      config <- mkConfig ca
-      restoreSuccessfull <- restoreCache restoreOverwrite (config & maxAge .~ restoreMaxAge)
-      case (restoreSuccessfull, restoreBaseBranch) of
-        (False, Just _) | restoreBaseBranch /= commonGitBranch -> do
-          let baseObjKey = mkObjectKey commonPrefix restoreBaseBranch commonSuffix
-          void $
-            restoreCache restoreOverwrite $
-            Config
-              commonBucket
-              baseObjKey
-              (config ^. confEnv)
-              commonVerbosity
-              commonConcise
-              restoreMaxAge
-              commonMaxBytes
-              commonNumRetries
-        _ -> return ()
-    RestoreStack (RestoreStackArgs {..}) -> do
+    Restore RestoreArgs {..} ->
+      withConfig ca $ \config -> do
+        restoreSuccessfull <-
+          runRIO (config & maxAge .~ restoreMaxAge) $ restoreCache restoreOverwrite
+        case (restoreSuccessfull, restoreBaseBranch) of
+          (False, Just _)
+            | restoreBaseBranch /= commonGitBranch -> do
+              app <- ask
+              let baseObjKey = mkObjectKey commonPrefix restoreBaseBranch commonSuffix
+                  config' =
+                    Config
+                      commonBucket
+                      baseObjKey
+                      (config ^. environment)
+                      commonVerbosity
+                      commonConcise
+                      restoreMaxAge
+                      commonMaxBytes
+                      commonNumRetries
+                      app
+              void $ runRIO config' $ restoreCache restoreOverwrite
+          _ -> return ()
+    RestoreStack RestoreStackArgs {..} -> do
       resolver <- getStackResolver restoreStackProject
       runCacheS3 (caStackSuffix resolver) (Restore restoreStackArgs)
-    RestoreStackWork (RestoreStackArgs {..}) -> do
+    RestoreStackWork RestoreStackArgs {..} -> do
       resolver <- getStackResolver restoreStackProject
       runCacheS3 (caStackWorkSuffix resolver) (Restore restoreStackArgs)
-    Clear -> mkConfig ca >>= run deleteCache
+    Clear -> withConfig ca (`runRIO` deleteCache)
     ClearStack proj -> do
       resolver <- getStackResolver proj
-      mkConfig (caStackSuffix resolver) >>= run deleteCache
+      withConfig (caStackSuffix resolver) (`runRIO` deleteCache)
     ClearStackWork proj -> do
       resolver <- getStackResolver proj
-      mkConfig (caStackWorkSuffix resolver) >>= run deleteCache
-
+      withConfig (caStackWorkSuffix resolver) (`runRIO` deleteCache)
 
 cacheS3Version :: Version
 cacheS3Version = Paths.version


### PR DESCRIPTION
Anyone feeling to give this PR a review please go ahead. If I don't hear anything within next few days, I'll go ahead and merge it. No new release will be following this PR immediately, since it doesn't change the way the tool itself operates, this refactor was done to simplify the codebase and make it more robust.

Contents of PR:

* Get rid of unnecessary dependencies

* Replace `monad-logger` with one from `rio`

* Drop usage of `safe-exceptions` in favor of `unliftio`

* Switched to `RIO.Process` for stack info.

* Simplified overall structure

Big thanks to: @jeffhappily 

Co-authored-by: Cheah Jer Fei <jeff@fpcomplete.com>